### PR TITLE
Fix: Show created by name into content-creation

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -69,7 +69,7 @@ else {
         $user = null;
         if(isset($validateToken["sub"])) $user = $userController->getByUsername($validateToken["sub"]);
         $_SESSION["user"] = $user;
-        $_SESSION["pk_user_id"] = $user->pk_user_id ?? 0;
+        $_SESSION["pk_user_id"] = $user["pk_user_id"] ?? 0;
         
         
         switch ($route) {


### PR DESCRIPTION
#What does this PR do?

- Change structure of the $_SESSION["pk_user_id"] = $user->pk_user_id to $_SESSION["pk_user_id"] = $user["pk_user_id"] to obtain the user_id correct